### PR TITLE
[WIP] OSX build not working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   global:
     - BINARYBUILDER_DOWNLOADS_CACHE=downloads
     - BINARYBUILDER_AUTOMATIC_APPLE=true
+    - MACOSX_DEPLOYMENT_TARGET=10.10
   # Our build takes too long for one job, so split targets across multiple jobs
   matrix:
     - TARGET=x86_64-apple-darwin14

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,7 @@ env:
     - BINARYBUILDER_AUTOMATIC_APPLE=true
   # Our build takes too long for one job, so split targets across multiple jobs
   matrix:
-    - TARGET=i686-linux-gnu
-    - TARGET=x86_64-linux-gnu
-    - TARGET=aarch64-linux-gnu
-    - TARGET=arm-linux-gnueabihf
-    - TARGET=powerpc64le-linux-gnu
     - TARGET=x86_64-apple-darwin14
-    - TARGET=i686-w64-mingw32
-    - TARGET=x86_64-w64-mingw32
 sudo: required
 
 jobs:


### PR DESCRIPTION
OSX builds are not yet working. In this branch I want to try out different things to fix that. Other platforms are disabled in Travis on this branch.

## Issue
```
gdal_mdreader.cpp:470:17: error: no member named 'back' in 'CPLString'
if (sString.back() == cChar)
~~~~~~~ ^
1 error generated.
make[1]: *** [../GDALmake.opt:652: gdal_mdreader.lo] Error 1
```
Link: https://travis-ci.org/visr/GDALBuilder/jobs/360575752#L600

This error was also noted in [this gdal-dev email](https://lists.osgeo.org/pipermail/gdal-dev/2017-April/046515.html).

## Tried
- [ ] `--without-cpp11` (didn't work then, and will not be possible in GDAL 2.3, which will require it)
- [x] Tried [this patch](https://github.com/visr/GDALBuilder/commit/19b0d57d094870b43dcbabf7f90bfb162bd32272) from this [gdal-dev email](https://lists.osgeo.org/pipermail/gdal-dev/2017-May/046634.html). It gets us to [the next error](https://travis-ci.org/visr/GDALBuilder/jobs/360610599#L608), build doesn't seem enough.
- [x] `MACOSX_DEPLOYMENT_TARGET=10.10` tried in https://github.com/visr/GDALBuilder/commit/afc9fe17e16804668183fade8dc1541b3cb85923, as done in https://www.kyngchaos.com/blog/2018/20180209_gdal_complete_2.2, gets us a step further

## Other ideas
Perhaps instead of trying this on Travis we should try this interactively in the BinaryBuilder wizard. Or perhaps people with experience building GDAL on OSX have ideas, would be much appreciated.
