### PR TITLE
Build Windows on GCC 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ env:
     - TARGET=arm-linux-musleabihf
     - TARGET=x86_64-apple-darwin14
     - TARGET=x86_64-unknown-freebsd11.1
-    - TARGET=i686-w64-mingw32
-    - TARGET=x86_64-w64-mingw32
+    - TARGET=i686-w64-mingw32-gcc7
+    - TARGET=x86_64-w64-mingw32-gcc7
 sudo: required
 
 jobs:

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -42,28 +42,25 @@ fi
     --enable-shared \
     --disable-static \
     "CC=$CC" \
-    "CXX=$CXX" \
+    "CXX=$CXX"
 
 make -j${nproc}
 make install
 
+# strip shared libraries to reduce filesize
 if [[ ${target} == *w64-mingw32* ]]; then
     strip $prefix/bin/*.dll
+elif [[ ${target} == *apple-darwin* ]]; then
+    strip $prefix/bin/*.dylib
+else
+    strip $prefix/bin/*.so
 fi
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    BinaryProvider.Linux(:i686, :glibc),
-    BinaryProvider.Linux(:x86_64, :glibc),
-    BinaryProvider.Linux(:aarch64, :glibc),
-    BinaryProvider.Linux(:armv7l, :glibc),
-    BinaryProvider.Linux(:powerpc64le, :glibc),
-    BinaryProvider.MacOS(),
-    BinaryProvider.Windows(:i686),
-    BinaryProvider.Windows(:x86_64)
-]
+platforms = supported_platforms()
+platforms = expand_gcc_versions(platforms)
 
 # The products that we will ensure are always built
 products(prefix) = [

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -51,7 +51,7 @@ make install
 if [[ ${target} == *w64-mingw32* ]]; then
     strip $prefix/bin/*.dll
 elif [[ ${target} == *apple-darwin* ]]; then
-    strip $prefix/lib/*.dylib
+    :
 else
     strip $prefix/lib/*.so
 fi

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -51,9 +51,9 @@ make install
 if [[ ${target} == *w64-mingw32* ]]; then
     strip $prefix/bin/*.dll
 elif [[ ${target} == *apple-darwin* ]]; then
-    strip $prefix/bin/*.dylib
+    strip $prefix/lib/*.dylib
 else
-    strip $prefix/bin/*.so
+    strip $prefix/lib/*.so
 fi
 """
 


### PR DESCRIPTION
To avoid what seems like cxx string ABI issues:
```
#0  0x00007ff98ba7475b in ntdll!RtlIsNonEmptyDirectoryReparsePointAllowed () from /cygdrive/c/WINDOWS/SYSTEM32/ntdll.dll
#1  0x00007ff98ba7c266 in ntdll!RtlpNtSetValueKey () from /cygdrive/c/WINDOWS/SYSTEM32/ntdll.dll
#2  0x00007ff98ba7c531 in ntdll!RtlpNtSetValueKey () from /cygdrive/c/WINDOWS/SYSTEM32/ntdll.dll
#3  0x00007ff98ba1a505 in ntdll!RtlRaiseStatus () from /cygdrive/c/WINDOWS/SYSTEM32/ntdll.dll
#4  0x00007ff98ba2990d in ntdll!memset () from /cygdrive/c/WINDOWS/SYSTEM32/ntdll.dll
#5  0x00007ff98ada98bc in msvcrt!free () from /cygdrive/c/WINDOWS/System32/msvcrt.dll
#6  0x000000006fcb40ea in libstdc++-6!_ZNSs9_M_mutateEyyy () from /cygdrive/c/bin/julia/bin/libstdc++-6.dll
#7  0x000000006fcb2d5e in libstdc++-6!_ZNSs15_M_replace_safeEyyPKcy () from /cygdrive/c/bin/julia/bin/libstdc++-6.dll
#8  0x000000006fcb3586 in libstdc++-6!_ZNSs6assignEPKcy () from /cygdrive/c/bin/julia/bin/libstdc++-6.dll
#9  0x000000002b510170 in libgdal-26!GTIFSetFromOGISDefnEx () from /cygdrive/c/Users/visser_mn/.julia/dev/GDAL/deps/usr/bin/libgdal-26.dll
#10 0x000000002b4e7aa7 in libgdal-26!_ZN12GTiffDataset10CreateCopyEPKcP11GDALDatasetiPPcPFidS1_PvES6_ () from /cygdrive/c/Users/visser_mn/.julia/dev/GDAL/deps/usr/bin/libgdal-26.dll
#11 0x000000002b7e854e in libgdal-26!_ZN10GDALDriver10CreateCopyEPKcP11GDALDatasetiPPcPFidS1_PvES6_ () from /cygdrive/c/Users/visser_mn/.julia/dev/GDAL/deps/usr/bin/libgdal-26.dll
#12 0x000000002aed4180 in ?? ()
```

Also strip shared libraries on other platforms.

(Locally this now passes all tests on GDAL.jl, except for having to set `PROJ_LIB` manually).