### PR TITLE
Enables CURL and GEOS. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ jobs:
 # Before anything else, get the latest versions of things
 before_script:
   - julia --color=yes -e 'using Pkg;
-      Pkg.add(PackageSpec(name="BinaryProvider", rev="master"));
-      Pkg.add(PackageSpec(name="BinaryBuilder", rev="master"))'
+      Pkg.add(PackageSpec(name="BinaryProvider", rev="v0.5.8"));
+      Pkg.add(PackageSpec(name="BinaryBuilder", rev="v0.1.4"))'
 
 script:
   - julia --color=yes build_tarballs.jl $TARGET

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -54,6 +54,7 @@ elif [[ ${target} == *freebsd* ]]; then
     # let's just use the GNU compiler instead.
     CC=gcc
     CXX=g++
+    CXXFLAGS=-D_GLIBCXX_USE_C99
 elif [[ ${target} == *64-linux* ]]; then
     # Symlink the library folder of mingw, so libstdc++ and
     # others can be found.
@@ -80,7 +81,8 @@ fi
     --enable-shared \
     --disable-static \
     "CC=$CC" \
-    "CXX=$CXX"
+    "CXX=$CXX" \
+    "CXXFLAGS=$CXXFLAGS"
 
 make -j${nproc}
 make install

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -39,14 +39,13 @@ make install
 # GDAL
 
 cd $WORKSPACE/srcdir/gdal-3.0.2/
-
+mkdir $prefix/$target
 if [[ ${target} == *w64-mingw32* ]]; then
     # Symlink libproj for Windows, else configure couldn't find it
     # TODO fix in PROJBuilder or in GDAL configure?
     ln -s $prefix/lib/libproj_6_1.dll.a $prefix/lib/libproj.dll.a
     # Also symlink the library folder of mingw, so libstdc++ and
     # others can be found. The path is ignored by BinaryBuilder.
-    mkdir $prefix/$target
     ln -s /opt/$target/$target/lib $prefix/$target/lib
 elif [[ ${target} == *freebsd* ]]; then
     # FreeBSD's default Clang ran into issues with configure
@@ -58,13 +57,11 @@ elif [[ ${target} == *freebsd* ]]; then
 elif [[ ${target} == *64-linux* ]]; then
     # Symlink the library folder of mingw, so libstdc++ and
     # others can be found.
-    mkdir $prefix/$target
     ln -s /opt/$target/$target/lib $prefix/$target/lib
     ln -s /opt/$target/$target/lib64/*.so* $prefix/lib/
 elif [[ ${target} == *i686-linux* ]]; then
     # Symlink the library folder so libstdc++ and
     # others can be found.
-    mkdir $prefix/$target
     ln -s /opt/$target/$target/lib $prefix/$target/lib
     ln -s /opt/$target/$target/lib/*.so* $prefix/lib/
 fi
@@ -95,6 +92,15 @@ elif [[ ${target} == *apple-darwin* ]]; then
 else
     strip $prefix/lib/libgdal.so
 fi
+
+# Cleanup
+rm -rf $prefix/$target
+for f in $prefix/lib/*; do
+  case "$(readlink "$f")" in /opt/$target/$target/*)
+    rm "$f"
+    ;;
+  esac
+done
 """
 
 # These are the platforms we will build for by default, unless further

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -81,7 +81,6 @@ fi
     --disable-static \
     "CC=$CC" \
     "CXX=$CXX"
-    #"CFLAGS=-Wl,-rpath-link=/opt/x86_64-linux-gnu/x86_64-linux-gnu/lib64"
 
 make -j${nproc}
 make install


### PR DESCRIPTION
Added Curl to build to include headers, symlinked sysroot libraries.

- [x] Add Curl build to have curl/curl.h for GDAL to actually build driver
- [x] Require MbedTLSBuilder or linker will fail configure
- [x] Linking requires rpath-link (`#"CFLAGS=-Wl,-rpath-link=/opt/x86_64-linux-gnu/x86_64-linux-gnu/lib64"`) for deps of curl/geos (libstc++ etc), but only works for curl. Added ln -s `/opt/$target/$target/lib/*.so* $prefix/lib/` for the same effect, works for both
- [x] Link sysroot libraries again to `$prefix/$target` for linking the build products

Some lessons for the next time. `./configure` had
`found libcurl version 7.64.1
checking for curl_global_init in -lcurl... no
`

Checking the `config.log` for errors 
`#/opt/x86_64-linux-gnu/bin/../lib/gcc/x86_64-linux-gnu/8.1.0/../../../../x86_64-linux-gnu/bin/ld: warning: libstdc++.so.6, needed by /workspace/destdir/lib/libgeos_c.so, not found (try using -rpath or -rpath-link)`

This can be check manually with `ld` and fixing it with `-rpath-link`, this doesn't give errors:
`/opt/x86_64-linux-gnu/bin/ld -rpath-link=/opt/x86_64-linux-gnu/x86_64-linux-gnu/lib64 /workspace/destdir/lib/libgeos_c.so`

To enable `-rpath-link` you need to pass the following to `./configure`
`CFLAGS=-Wl,-rpath-link=/opt/x86_64-linux-gnu/x86_64-linux-gnu/lib64"`
